### PR TITLE
avoid a crash whey a 'SKY' doesn't contain 'satellites'

### DIFF
--- a/gpsd_exporter.py
+++ b/gpsd_exporter.py
@@ -351,12 +351,18 @@ def getPositionData(gpsd, metrics, args):
             })
     
     elif nx['class'] == 'SKY':
+        satellites = nx.get('satellites')
+        if satellites is None:
+            log.debug (f'no satellites in SKY')
+            log.debug (nx)
+            return
+
         metrics['SEEN'].set(0)
         metrics['USED'].set(0)
         sat_before = metrics['SAT_STATUS'].keys()
         sat_here = []
             
-        for sat in nx['satellites']:
+        for sat in satellites:
             if not sat['PRN'] in sat_before:
                 log.info (f'New Sat {sat["PRN"]} added!')
                 log.debug (f'data {sat}')


### PR DESCRIPTION
I faced an issue when I upgraded gpsd from 3.22 to 3.25 that `SKY` doesn't always contain `satellites`

just check if a `SKY` has `satellites` before processing it.