### PR TITLE
Fix global socket timeout affecting Prometheus HTTP server

### DIFF
--- a/gpsd_exporter.py
+++ b/gpsd_exporter.py
@@ -516,15 +516,17 @@ def drop_privileges(uid_name='nobody', gid_name='nogroup'):
 def loop_connection(metrics, args):
 
     try:
-        # Set socket timeout for the connection
-        socket.setdefaulttimeout(args.timeout)
-        
         log.info(f'Attempting to connect to gpsd at {args.hostname}:{args.port} with {args.timeout}s timeout')
         gpsd = gps.gps(host=args.hostname, port=args.port, verbose=1, mode=gps.WATCH_ENABLE | gps.WATCH_NEWSTYLE | gps.WATCH_SCALED)
 
         if not gpsd:
             log.critical(f'Could not connect to gpsd at {args.hostname}:{args.port}')
             raise ConnectionRefusedError(f'Failed to establish connection to gpsd at {args.hostname}:{args.port}')
+
+        # Set timeout on the gpsd socket only (not globally, which would
+        # also affect the Prometheus HTTP server sockets)
+        if hasattr(gpsd, 'ser') and hasattr(gpsd.ser, 'sock') and gpsd.ser.sock:
+            gpsd.ser.sock.settimeout(args.timeout)
 
         log.info(f'Successfully connected to gpsd at {args.hostname}:{args.port}')
         drop_privileges()


### PR DESCRIPTION
## Summary

- `socket.setdefaulttimeout()` was setting the timeout globally, which also applied to the Prometheus HTTP server's client sockets
- This caused `TimeoutError` exceptions when handling `/metrics` scrape requests
- Replaced with `gpsd.ser.sock.settimeout()` to scope the timeout to only the gpsd connection socket

## Test plan

- [x] Verify exporter starts and connects to gpsd normally
- [x] Confirm `/metrics` endpoint responds without `TimeoutError` under load
- [x] Verify gpsd socket still times out correctly on connection loss